### PR TITLE
Adds SoapCall definition and changes formatter to return that

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 All notable changes to `tbpixel/soap-client` will be documented in this file.
 
+## 0.2.0 - 2019-03-12
+
+- Adds SoapCall definition and changes formatter to return that; resolves #3.
+
 ## 0.1.0 - 2019-03-04
 
 - Development release

--- a/src/ClientFactory.php
+++ b/src/ClientFactory.php
@@ -18,7 +18,7 @@ final class ClientFactory
         $soap = new \SoapClient($wsdl, $soapOptions);
         $guzzle = new Guzzle;
         $formatter = new SoapRequestFormatter($wsdl, $soapOptions);
-        $handler = new GuzzleHandler($guzzle, $formatter, $wsdl);
+        $handler = new GuzzleHandler($guzzle, $formatter);
 
         return new Client($wsdl, $soap, $handler);
     }

--- a/src/Exceptions/RequestFormatterHack.php
+++ b/src/Exceptions/RequestFormatterHack.php
@@ -2,6 +2,21 @@
 
 namespace TBPixel\SoapClient\Exceptions;
 
+use TBPixel\SoapClient\Handlers\SoapCall;
+
 final class RequestFormatterHack extends \Exception
 {
+    /** @var \TBPixel\SoapClient\Handlers\SoapCall */
+    private $soapCall;
+
+    public function __construct(SoapCall $soapCall)
+    {
+        parent::__construct();
+        $this->soapCall = $soapCall;
+    }
+
+    public function getSoapCall(): SoapCall
+    {
+        return $this->soapCall;
+    }
 }

--- a/src/Formatters/SoapRequestFormatter.php
+++ b/src/Formatters/SoapRequestFormatter.php
@@ -2,6 +2,7 @@
 
 namespace TBPixel\SoapClient\Formatters;
 
+use TBPixel\SoapClient\Handlers\SoapCall;
 use TBPixel\SoapClient\Handlers\Formatter;
 use TBPixel\SoapClient\Exceptions\RequestFormatterHack;
 
@@ -27,17 +28,17 @@ final class SoapRequestFormatter extends \SoapClient implements Formatter
         // This is a MASSIVE hack. It is very important that a formatter be rewritten,
         // or a new one provided, to ensure formatting of requests is handled correctly.
         // Invalid requests will cause weird bugs because of this process.
-        throw new RequestFormatterHack($request);
+        throw new RequestFormatterHack(new SoapCall($action, $location, $request));
     }
 
-    public function format(string $action, array $body): string
+    public function format(string $action, array $body): SoapCall
     {
         try {
             $this->__soapCall($action, $body);
             // NOTE!
             // See __doRequest comment for info about this hack.
         } catch (RequestFormatterHack $hack) {
-            return $hack->getMessage();
+            return $hack->getSoapCall();
         }
     }
 }

--- a/src/Handlers/Formatter.php
+++ b/src/Handlers/Formatter.php
@@ -10,5 +10,5 @@ interface Formatter
     /**
      * Accepts an array of data and formats it in the appropriate request structure.
      */
-    public function format(string $action, array $body): string;
+    public function format(string $action, array $body): SoapCall;
 }

--- a/src/Handlers/GuzzleHandler.php
+++ b/src/Handlers/GuzzleHandler.php
@@ -25,29 +25,22 @@ final class GuzzleHandler implements Handler
      */
     private $formatter;
 
-    /**
-     * The service endpoint to make a request to.
-     *
-     * @var string
-     */
-    private $uri;
-
-    public function __construct(ClientInterface $client, Formatter $formatter, string $uri)
+    public function __construct(ClientInterface $client, Formatter $formatter)
     {
         $this->client = $client;
         $this->formatter = $formatter;
-        $this->uri = $uri;
     }
 
     public function request(string $action, array $body): StreamInterface
     {
         try {
-            $response = $this->client->request('POST', $this->uri, [
+            $soapCall = $this->formatter->format($action, $body);
+            $response = $this->client->request('POST', $soapCall->getLocation(), [
                 'headers' => [
                     'content-type' => 'text/xml',
-                    'SOAPAction' => $action,
+                    'SOAPAction' => $soapCall->getAction(),
                 ],
-                'body' => $this->formatter->format($action, $body),
+                'body' => $soapCall->getBody(),
             ]);
 
             return $response->getBody();

--- a/src/Handlers/SoapCall.php
+++ b/src/Handlers/SoapCall.php
@@ -1,0 +1,43 @@
+<?php
+
+namespace TBPixel\SoapClient\Handlers;
+
+final class SoapCall
+{
+    /**
+     * @var string
+     */
+    private $action;
+
+    /**
+     * @var string
+     */
+    private $location;
+
+    /**
+     * @var string
+     */
+    private $body;
+
+    public function __construct(string $action, string $location, string $body)
+    {
+        $this->action = $action;
+        $this->location = $location;
+        $this->body = $body;
+    }
+
+    public function getAction(): string
+    {
+        return $this->action;
+    }
+
+    public function getLocation(): string
+    {
+        return $this->location;
+    }
+
+    public function getBody(): string
+    {
+        return $this->body;
+    }
+}

--- a/tests/ClientTest.php
+++ b/tests/ClientTest.php
@@ -34,6 +34,14 @@ final class ClientTest extends TestCase
     }
 
     /** @test */
+    public function can_make_client_with_factory()
+    {
+        $client = ClientFactory::new($this->wsdl);
+
+        $this->assertInstanceOf(Client::class, $client);
+    }
+
+    /** @test */
     public function can_parse_wsdl()
     {
         $handler = new HandlerMock;

--- a/tests/PsrHandlerTest.php
+++ b/tests/PsrHandlerTest.php
@@ -3,8 +3,12 @@
 namespace TBPixel\SoapClient\Tests;
 
 use Mockery;
+use GuzzleHttp\Psr7\Request;
 use PHPUnit\Framework\TestCase;
 use Psr\Http\Client\ClientInterface;
+use Psr\Http\Message\StreamInterface;
+use Psr\Http\Message\ResponseInterface;
+use TBPixel\SoapClient\Handlers\SoapCall;
 use TBPixel\SoapClient\Handlers\PsrHandler;
 use TBPixel\SoapClient\Formatters\SoapRequestFormatter;
 
@@ -29,18 +33,51 @@ final class PsrHandlerTest extends TestCase
         Mockery::close();
     }
 
+    /**
+     * Mocks and returns a PSR compatible failed request which throws an exception.
+     *
+     * @return \Psr\Http\Client\ClientInterface
+     */
+    private function mockClientFailedRequest()
+    {
+        return Mockery::mock(ClientInterface::class)
+            ->shouldReceive('sendRequest')
+            ->andThrow(\Exception::class)
+            ->getMock();
+    }
+
+    /**
+     * Mocks and returns a PSR compatible successful request.
+     *
+     * @return \Psr\Http\Client\ClientInterface
+     */
+    private function mockClientSuccessfulRequest(SoapCall $soapCall, string $result)
+    {
+        $stream = Mockery::mock(StreamInterface::class)
+            ->shouldReceive('getContents')
+            ->andReturn($result)
+            ->getMock();
+
+        $response = Mockery::mock(ResponseInterface::class)
+            ->shouldReceive('getBody')
+            ->andReturn($stream)
+            ->getMock();
+
+        return Mockery::mock(ClientInterface::class)
+            ->shouldReceive('sendRequest')
+            ->andReturn($response)
+            ->getMock();
+    }
+
     /** @test */
     public function failed_request_will_throw_runtime_exception()
     {
         $this->expectException(\RuntimeException::class);
 
-        $mock = Mockery::mock(ClientInterface::class)
-            ->shouldReceive('sendRequest')
-            ->andThrow(\Exception::class)
-            ->getMock();
+        $mock = $this->mockClientFailedRequest();
 
         $formatter = new SoapRequestFormatter($this->wsdl);
-        $handler = new PsrHandler($mock, $formatter, $this->wsdl);
+        $handler = new PsrHandler($mock, $formatter);
 
         $handler->request('SayHelloTo', [
             'Person' => [
@@ -48,5 +85,27 @@ final class PsrHandlerTest extends TestCase
                 'LastName' => 'Doe',
             ]
         ]);
+    }
+
+    /** @test */
+    public function successful_request_should_return_valid_response()
+    {
+        $action = 'SayHelloTo';
+        $body = [
+            'Person' => [
+                'FirstName' => 'John',
+                'LastName' => 'Doe',
+            ],
+        ];
+        $result = 'success';
+
+        $formatter = new SoapRequestFormatter($this->wsdl);
+        $soapCall = $formatter->format($action, $body);
+        $mock = $this->mockClientSuccessfulRequest($soapCall, $result);
+
+        $handler = new PsrHandler($mock, $formatter);
+        $response = $handler->request($action, $body);
+
+        $this->assertEquals($result, $response->getContents());
     }
 }

--- a/tests/SoapRequestFormatterTest.php
+++ b/tests/SoapRequestFormatterTest.php
@@ -29,8 +29,10 @@ final class SoapRequestFormatterTest extends TestCase
 
         $person = file_get_contents(__DIR__ . '/data/SayHelloPerson.xml');
         $expected = trim(preg_replace('/\s+/', '', $person));
-        $actual = trim(preg_replace('/\s+/', '', $request));
+        $actual = trim(preg_replace('/\s+/', '', $request->getBody()));
 
+        $this->assertEquals('SayHelloTo', $request->getAction());
+        $this->assertEquals('http://localhost/SayHello/', $request->getLocation());
         $this->assertEquals($expected, $actual);
     }
 }

--- a/tests/data/SayHello.wsdl
+++ b/tests/data/SayHello.wsdl
@@ -1,14 +1,15 @@
 <?xml version="1.0" encoding="utf-8"?>
-<definitions name="SayHello" targetNamespace="http://localhost/SayHello/"
-    xmlns="http://schemas.xmlsoap.org/wsdl/"
-    xmlns:tns="http://localhost/SayHello/"
-    xmlns:xsd="http://localhost/SayHello/scheme"
+<definitions name="SayHello" targetNamespace="http://localhost/SayHello/" 
+    xmlns="http://schemas.xmlsoap.org/wsdl/" 
+    xmlns:tns="http://localhost/SayHello/" 
+    xmlns:xsd="http://localhost/SayHello/scheme" 
     xmlns:soap="http://schemas.xmlsoap.org/wsdl/soap/">
 
     <documentation xmlns="http://schemas.xmlsoap.org/wsdl/">A service that says hello</documentation>
 
     <types>
-        <schema targetNamespace="http://localhost/SayHello/scheme" xmlns="http://www.w3.org/2001/XMLSchema">
+        <schema targetNamespace="http://localhost/SayHello/scheme" 
+            xmlns="http://www.w3.org/2001/XMLSchema">
 
             <element name="Person">
                 <complexType>


### PR DESCRIPTION
This update changes the way a `Handler` formats the request by requiring the formatter to return a `SoapCall` instance instead of a body string. This instance contains all required soap call information including the HTTP URI, fully-qualified action name and body.